### PR TITLE
add init func for class

### DIFF
--- a/Birdee/Parser.cpp
+++ b/Birdee/Parser.cpp
@@ -336,14 +336,20 @@ std::unique_ptr<NewExprAST> ParseNew()
 	{
 		if (tokenizer.CurTok == tok_colon)
 		{
-			tokenizer.GetNextToken();//eat :
+			tokenizer.GetNextToken(); //eat :
 			CompileAssert(tokenizer.CurTok == tok_identifier, "Expected an identifier after :");
 			method = tokenizer.IdentifierStr;
 			tokenizer.GetNextToken();
+			if (tokenizer.CurTok == tok_left_bracket)
+			{
+				tokenizer.GetNextToken(); //eat (
+				expr = ParseArguments();
+			}
 		}
-		if (tokenizer.CurTok == tok_left_bracket)
+		else if (tokenizer.CurTok == tok_left_bracket) // new Object(...)
 		{
-			tokenizer.GetNextToken();//eat (
+			method = "__init__";
+			tokenizer.GetNextToken(); // eat (
 			expr = ParseArguments();
 		}
 	}


### PR DESCRIPTION
**Grammer:**
dim obj as Obj = new Obj
**or**
dim obj as Obj = new Obj(...)

For the first grammer, the compiler will try to find a initializing function without argument, it there's none, then no initialization will be done;
And for the second one, there must be a matched initializing function defined.